### PR TITLE
fix: Move nickname dto

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.final2.yoseobara.controller;
 
+import com.final2.yoseobara.dto.request.NicknameRequestDto;
 import com.final2.yoseobara.dto.request.LoginRequestDto;
 import com.final2.yoseobara.dto.request.MemberRequestDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
@@ -70,6 +70,12 @@ public class PostController {
         return postService.getPost(postId);
     }
 
+    // 게시물 페이지네이션
+    @GetMapping("/paging")
+    public List<PostResponseDto> getPostListPaging(@RequestParam int page){
+        return null;
+    }
+
     // 게시물 수정
     @PutMapping("/{postId}")
     public ResponseDto<?> updatePost(@PathVariable Long postId,

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/NicknameRequestDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/NicknameRequestDto.java
@@ -1,4 +1,4 @@
-package com.final2.yoseobara.controller.request;
+package com.final2.yoseobara.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.final2.yoseobara.service;
 
 import com.final2.yoseobara.dto.request.LoginRequestDto;
+import com.final2.yoseobara.dto.request.NicknameRequestDto;
 import com.final2.yoseobara.dto.request.TokenDto;
 import com.final2.yoseobara.dto.request.MemberRequestDto;
 import com.final2.yoseobara.dto.response.ResponseDto;


### PR DESCRIPTION
- Dto 패키지를 별도로 생성했는데 
기존의 develop 브랜치의 NicknameDto 파일을 수정하지 않고 머지하여
실행이 되지 않아 위치를 옮겼습니다.