### PR TITLE
feat: Add main page listing(infinite scroll, search, sorting) , Fix location type, post response dto, yml(sql)

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
@@ -12,6 +12,10 @@ import com.final2.yoseobara.service.PostService;
 import com.final2.yoseobara.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -58,22 +62,29 @@ public class PostController {
     }
 
     // 게시글 전체 조회
-    @GetMapping
-    public List<PostResponseDto> getPostList(){
-        return postService.getPostList();
+    @GetMapping("/all")
+    public ResponseDto<?> getPostList(){
+        return ResponseDto.success(postService.getPostList());
     }
 
     // 게시물 상세 조회
     @ResponseBody
     @GetMapping("/{postId}")
-    public PostResponseDto getPost(@PathVariable Long postId){
-        return postService.getPost(postId);
+    public ResponseDto<?> getPost(@PathVariable Long postId){
+        return ResponseDto.success(postService.getPost(postId));
     }
 
-    // 게시물 페이지네이션
-    @GetMapping("/paging")
-    public List<PostResponseDto> getPostListPaging(@RequestParam int page){
-        return null;
+    // 메인페이지 리스팅 (무한스크롤 슬라이스)
+    // search 는 검색할 항목, keyword 는 검색 키워드, 파라미터 null 이면 빈문자열 보냄
+    // 정렬은 pageable 의 sort 에서 설정
+    // 정렬 기준과 방향을 파라미터로 받고, 정렬 기준이 없거나 같은 값이 나와도 디폴트는 최신순임
+    // 페이저블 파라미터 아예 없을 때(디폴트)는 최신순, 10개씩, 첫페이지 반환
+    @GetMapping
+    public ResponseDto<?> getPostSlice(@RequestParam(value = "search", defaultValue = "") String search,
+                                       @RequestParam(value = "keyword", defaultValue = "") String keyword,
+                                       @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+        //Slice<Post> postSlice = postRepository.findAll(pageable);
+        return ResponseDto.success(postService.getPostSlice(search, keyword, pageable));
     }
 
     // 게시물 수정

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
@@ -1,5 +1,6 @@
 package com.final2.yoseobara.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.vladmihalcea.hibernate.type.json.JsonType;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,13 +35,14 @@ public class Post extends Timestamped {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @JsonIgnore
     private Member member;
     @Column
     private String address; // 주소
 
     @Column(columnDefinition = "json") // 원하는 것 -> { Lat: 좌표값, lng: 좌표값 }
     @Type(type = "json") // 괜찮은 건지 모르겠음. 작동되는 것 보고 수정할 듯
-    private HashMap<String,Float> location;
+    private HashMap<String,Double> location;
 
 //    @Column(name = "image_urls") // post_image_urls 테이블이 생김
 //    @ElementCollection(targetClass = String.class) // 값 타입 컬렉션 맵, 기본적으로 OneToMany
@@ -53,12 +55,16 @@ public class Post extends Timestamped {
     @Column
     private String thumbnailUrl;
 
+    private Long view; // 계산된 조회수
+    private Long heart; // 계산된 좋아요
+
+
     public void setMember(Member member) {
         this.member = member;
     }
 
     @Builder
-    public Post(String title, String content,String address, HashMap<String,Float> location, List<String> imageUrls) {
+    public Post(String title, String content,String address, HashMap<String,Double> location, List<String> imageUrls) {
         //this.member = member;
         this.title = title;
         this.content = content;
@@ -70,10 +76,12 @@ public class Post extends Timestamped {
         List<String> temp = new ArrayList<>(imageUrls.subList(1,imageUrls.size()));
         this.imageUrls = temp;
         this.thumbnailUrl = imageUrls.get(0);
+        this.view = 0L;
+        this.heart = 0L;
     }
 
     // 멤버는 어차피 권한 확인 하는데 필요하나? 위에 거랑 이거 중간에 Dto로 묶는 게 나을 듯?
-    public void update(String title, String content, String address, HashMap<String,Float> location) {
+    public void update(String title, String content, String address, HashMap<String,Double> location) {
         //this.member = member;
         this.title = title;
         this.content = content;

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/PostRequestDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/PostRequestDto.java
@@ -13,6 +13,6 @@ public class PostRequestDto {
     private String title;
     private String content;
     private String address;
-    private HashMap<String,Float> location;
+    private HashMap<String,Double> location;
 
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
@@ -14,11 +14,11 @@ import java.util.List;
 @Getter
 
 public class PostResponseDto {
-    private Long postid;
+    private Long postId;
     private String title;
     private String content;
     private String address;
-    private HashMap<String, Float> location;
+    private HashMap<String, Double> location;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime createdAt;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
@@ -31,18 +31,18 @@ public class PostResponseDto {
     private String nickname; // 로그인된 작성자의 닉네임 받아오기
 
     @Builder // 이미지와 썸네일 추가하기
-    public PostResponseDto(Post post, Long view, Long heart, String nickname) {
-        this.postid = post.getPostId();
+    public PostResponseDto(Post post, List<String> imageUrls, String nickname) {
+        this.postId = post.getPostId();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.address = post.getAddress();
         this.location = post.getLocation();
         this.createdAt = post.getCreatedAt();
         this.modifiedAt = post.getModifiedAt();
-        this.imageUrls = post.getImageUrls();
+        this.imageUrls = imageUrls;
         this.thumbnailUrl = post.getThumbnailUrl();
-        this.view = view;
-        this.heart = heart;
+        this.view = post.getView();
+        this.heart = post.getHeart();
         this.nickname = nickname;
     }
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
@@ -2,8 +2,12 @@ package com.final2.yoseobara.repository;
 
 
 import com.final2.yoseobara.domain.Post;
-import com.final2.yoseobara.dto.response.PostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -14,6 +18,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findById(Long postId);
 
-    List<String> findImageUrlsByPostId(Long postId);
+    Slice<Post> findAllByTitleContainingOrContentContainingOrMember_NicknameContaining(String title, String content, String nickname, Pageable pageable);
+
+    @Query("select p from Post p")
+    public Slice<Post> findAllDefault(Pageable pageable);
 
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -6,13 +6,17 @@ import com.final2.yoseobara.dto.request.PostRequestDto;
 import com.final2.yoseobara.dto.response.PostResponseDto;
 import com.final2.yoseobara.domain.Member;
 import com.final2.yoseobara.domain.Post;
-import com.final2.yoseobara.domain.UserDetailsImpl;
-import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.exception.InvalidValueException;
 import com.final2.yoseobara.repository.MemberRepository;
 import com.final2.yoseobara.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.querydsl.QPageRequest;
+import org.springframework.data.querydsl.QSort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -37,6 +41,8 @@ public class PostService {
         for (Post post : posts) {
             PostResponseDto postResponseDto = PostResponseDto.builder()
                     .post(post)
+                    .imageUrls(post.getImageUrls())
+                    .nickname(post.getMember().getNickname())
                     .build();
             postList.add(postResponseDto);
         }
@@ -53,8 +59,51 @@ public class PostService {
                 .post(post)
                 //.view(post.getView())
                 //.heart(post.getHeart())
+                .imageUrls(post.getImageUrls())
                 .nickname(post.getMember().getNickname())
                 .build();
+    }
+
+    // Post 슬라이스 -> 무한스크롤은 페이지보다 슬라이스가 좋음 (카운트를 하지 않아서)
+    public Slice<PostResponseDto> getPostSlice(String search, String keyword, Pageable pageable) {
+
+        // 정렬의 디폴트는 최신순
+        Sort sort = pageable.getSort().and(Sort.by("createdAt").descending());
+        Pageable page = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+
+        // 검색 조건이 아니면 검색에 쓰이면 안되므로 널
+        String title = null;
+        String content = null;
+        String nickname = null;
+        if (Objects.nonNull(search)) {
+            switch (search) {
+                case "title":
+                    title = keyword;
+                    break;
+                case "content":
+                    content = keyword;
+                    break;
+                case "nickname":
+                    nickname = keyword;
+                    break;
+                // 검색 파라미터 없으면 빈문자열임 -> 검색 안하고 전체 조회
+                case "":
+                    return postRepository.findAllDefault(page).map(post -> PostResponseDto.builder()
+                            .post(post)
+                            .nickname(post.getMember().getNickname())
+                            .build());
+            }
+        }
+
+        // 검색 조건이 있으면 검색에 쓰이는 파라미터만 키워드를 값으로 가지고 나머진 null 임
+        Slice<Post> postSlice = postRepository.findAllByTitleContainingOrContentContainingOrMember_NicknameContaining(title, content, nickname, page);
+        Slice<PostResponseDto> postDtoSlice = postSlice.map(
+                post -> PostResponseDto.builder()
+                        .post(post)
+                        .nickname(post.getMember().getNickname())
+                        .build()
+        );
+        return postDtoSlice;
     }
 
     // Post 생성
@@ -78,8 +127,7 @@ public class PostService {
         
         PostResponseDto postResponseDto = PostResponseDto.builder()
                 .post(post)
-                .view(0L)
-                .heart(0L)
+                .imageUrls(post.getImageUrls())
                 .nickname(memberFoundById.getNickname())
                 .build();
         return postResponseDto;
@@ -102,11 +150,14 @@ public class PostService {
             throw new InvalidValueException(ErrorCode.POST_UNAUTHORIZED);
         }
 
-        // 이미지가 존재하면 S3와 DB 업데이트
+        // 이미지가 존재하면 S3와 DB 업데이트 -> 이미지가 없으면 기존 이미지 유지이긴 한데 1개 이상으로 설정해서 일단 그냥 덮어씌우는 걸로
+        // 기존 이미지인지 확인 기능 찾아보기 (파일의 URL 혹은 메타데이터 등?)
         if (newImages != null) {
-            // 새로운 이미지 3개 이하
+            // 이미지 1개 이상 3개 이하
             if(newImages.length > 3) {
                 throw new InvalidValueException(ErrorCode.POST_IMAGE_MAX);
+            } else if (newImages.length < 1) {
+                throw new InvalidValueException(ErrorCode.POST_IMAGE_REQUIRED);
             }
 
             List<String> imageUrls = s3Service.updateFile(post.getImageUrls(), post.getThumbnailUrl(), newImages);
@@ -124,7 +175,11 @@ public class PostService {
         // DB에 저장
         postRepository.save(post);
 
-        return PostResponseDto.builder().post(post).build();
+        return PostResponseDto.builder()
+                .post(post)
+                .imageUrls(post.getImageUrls())
+                .nickname(memberFoundById.getNickname())
+                .build();
     }
 
     // Post 삭제

--- a/yoseobara/src/main/resources/application.yml
+++ b/yoseobara/src/main/resources/application.yml
@@ -14,13 +14,21 @@ spring:
     password: ${jdbc.password}
 
   jpa:
-    show_sql: true
-    hibernate:
-      format_sql: true
-      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        ddl-auto: update
+        default_batch_fetch_size: 100
+        use_sql_comments: true
 
 logging:
     level:
+      org:
+        hibernate:
+          type:
+            descriptor:
+              sql: trace
       root: INFO
 
 server:


### PR DESCRIPTION
- 메인 페이지 리스팅
- 무한스크롤을 고려한 페이지네이션 (슬라이스)
- 검색 기능 추가
- 정렬 기능 추가
- location 타입 double로 수정
- 메인 페이지 리스팅에 썸네일만 보내기 위해 postResponseDto 수정 (조회수, 좋아요, 닉네임 null 로 나오던 것도 수정)
- yml 파일에 SQL 관련 추가 (오히려 지저분할 수도 있으니 필요없으면 지우세요)

Resolves #29 #33 #34 #38