### PR TITLE
feat: Add posts within map bounds, Add convert coordinates to address

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.final2.yoseobara.controller;
 
 import com.final2.yoseobara.domain.Post;
+import com.final2.yoseobara.dto.request.MapRequestDto;
 import com.final2.yoseobara.dto.request.PostRequestDto;
 import com.final2.yoseobara.dto.response.PostResponseDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
@@ -73,6 +74,13 @@ public class PostController {
     public ResponseDto<?> getPost(@PathVariable Long postId){
         return ResponseDto.success(postService.getPost(postId));
     }
+
+    // 게시물 범위내 조회
+    @PostMapping("/bounds")
+    public ResponseDto<?> getPostListByBounds(@RequestBody MapRequestDto mapRequestDto){
+        return ResponseDto.success(postService.getPostListByBounds(mapRequestDto));
+    }
+
 
     // 메인페이지 리스팅 (무한스크롤 슬라이스)
     // search 는 검색할 항목, keyword 는 검색 키워드, 파라미터 null 이면 빈문자열 보냄

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
@@ -40,9 +40,13 @@ public class Post extends Timestamped {
     @Column
     private String address; // 주소
 
-    @Column(columnDefinition = "json") // 원하는 것 -> { Lat: 좌표값, lng: 좌표값 }
-    @Type(type = "json") // 괜찮은 건지 모르겠음. 작동되는 것 보고 수정할 듯
-    private HashMap<String,Double> location;
+//    @Column(columnDefinition = "json") // 원하는 것 -> { Lat: 좌표값, lng: 좌표값 }
+//    @Type(type = "json") // 괜찮은 건지 모르겠음. 작동되는 것 보고 수정할 듯
+//    private HashMap<String,Double> location;
+
+    private Double lng;
+    private Double lat;
+
 
 //    @Column(name = "image_urls") // post_image_urls 테이블이 생김
 //    @ElementCollection(targetClass = String.class) // 값 타입 컬렉션 맵, 기본적으로 OneToMany
@@ -69,9 +73,11 @@ public class Post extends Timestamped {
         this.title = title;
         this.content = content;
         this.address = address;
-        this.location = new LinkedHashMap<>();
-        this.location.put("lat",location.get("lat"));
-        this.location.put("lng",location.get("lng"));
+        this.lng = location.get("lng");
+        this.lat = location.get("lat");
+//        this.location = new LinkedHashMap<>();
+//        this.location.put("lat",location.get("lat"));
+//        this.location.put("lng",location.get("lng"));
         // 서브리스트 문제 때문에 임시로 만든 변수
         List<String> temp = new ArrayList<>(imageUrls.subList(1,imageUrls.size()));
         this.imageUrls = temp;
@@ -86,8 +92,10 @@ public class Post extends Timestamped {
         this.title = title;
         this.content = content;
         this.address = address;
-        this.location.replace("lat",location.get("lat"));
-        this.location.replace("lng",location.get("lng"));
+        this.lng = location.get("lng");
+        this.lat = location.get("lat");
+//        this.location.replace("lat",location.get("lat"));
+//        this.location.replace("lng",location.get("lng"));
     }
 
     // 멤버 정보 추가 ?? 굳이 메소드 만드는 이유? 빌더에서 그냥 넣으면 안되나?

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/MapRequestDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/MapRequestDto.java
@@ -1,0 +1,13 @@
+package com.final2.yoseobara.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+public class MapRequestDto {
+    private HashMap<String, HashMap<String, Double>> bounds;
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
@@ -36,7 +36,9 @@ public class PostResponseDto {
         this.title = post.getTitle();
         this.content = post.getContent();
         this.address = post.getAddress();
-        this.location = post.getLocation();
+        this.location = new HashMap<>();
+        this.location.put("lng", post.getLng());
+        this.location.put("lat", post.getLat());
         this.createdAt = post.getCreatedAt();
         this.modifiedAt = post.getModifiedAt();
         this.imageUrls = imageUrls;

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/RGAddressDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/RGAddressDto.java
@@ -1,0 +1,16 @@
+package com.final2.yoseobara.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class RGAddressDto {
+    private String man_made;
+    private String road;
+    private String suburb;
+    private String village;
+    private String town;
+    private String city;
+    private String province;
+    private String postcode;
+    private String country;
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/RGResultDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/RGResultDto.java
@@ -1,0 +1,9 @@
+package com.final2.yoseobara.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class RGResultDto {
+    private RGAddressDto address;
+    private String display_name;
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
@@ -23,4 +23,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("select p from Post p")
     public Slice<Post> findAllDefault(Pageable pageable);
 
+    // 범위 내 location 조회
+    @Query("select p from Post p where p.lng between :swLng and :neLng and p.lat between :swLat and :neLat")
+    public List<Post> findAllByBounds(@Param("swLng") Double swLng, @Param("neLng") Double neLng, @Param("swLat") Double swLat, @Param("neLat") Double neLat);
+
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -165,11 +165,11 @@ public class PostService {
         RestTemplate restTemplate = new RestTemplate();
         RGResultDto result = restTemplate.getForObject(url, RGResultDto.class);
 
-        if (result == null) {
-            return "주소를 찾을 수 없습니다.";
+        if (result.getAddress() == null) {
+            return "주소 없음";
         }
 
-        if (!Objects.equals(result.getAddress().getCountry(), "대한민국")) {
+        if (!Objects.equals(result.getAddress().getCountry(), "대한민국") || result.getAddress().getCountry() == null) {
             return result.getDisplay_name();
         }
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -165,6 +165,10 @@ public class PostService {
         RestTemplate restTemplate = new RestTemplate();
         RGResultDto result = restTemplate.getForObject(url, RGResultDto.class);
 
+        if (result == null) {
+            return "주소를 찾을 수 없습니다.";
+        }
+
         if (result.getAddress().getCountry() != "대한민국") {
             return result.getDisplay_name();
         }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -169,7 +169,7 @@ public class PostService {
             return "주소를 찾을 수 없습니다.";
         }
 
-        if (result.getAddress().getCountry() != "대한민국") {
+        if (!Objects.equals(result.getAddress().getCountry(), "대한민국")) {
             return result.getDisplay_name();
         }
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -165,9 +165,9 @@ public class PostService {
         RestTemplate restTemplate = new RestTemplate();
         RGResultDto result = restTemplate.getForObject(url, RGResultDto.class);
 
-//        if (result.getAddress().getCountry() != "대한민국") {
-//            return "해외";
-//        }
+        if (result.getAddress().getCountry() != "대한민국") {
+            return result.getDisplay_name();
+        }
 
         String[] address = result.getDisplay_name().split(", ");
         Collections.reverse(Arrays.asList(address));


### PR DESCRIPTION
기존에 하려던 방식이 잘 되지 않아 일단은 비효율적일 수 있지만 구현만 해놨습니다.
추후에 개선하면 좋겠습니다.
Point 타입으로 저장하여 MySQL 의 Spatial 관련 함수를 쓰면 좋을 것 같습니다.
주소 변환 api 의 경우, key 를 받지 않아도 되는 Nominatim 이라는 오픈소스를 사용하였는데
상세 주소도 나오지 않고 프론트엔드 쪽에서 카카오 api를 쓰기 때문에 변경할 생각입니다.

- 입력 받은 범위 내 게시물 리스트 (Post 메소드, MBR)
- 입력 받은 좌표 주소로 변환 (Nominatim api, 추후 kakao map api 로 변경 예정)
- 필요한 dto 생성 등

Resolves #35 #40