### PR TITLE
feat: 카카오 소셜로그인 기능 구현

### DIFF
--- a/yoseobara/build.gradle
+++ b/yoseobara/build.gradle
@@ -55,6 +55,10 @@ dependencies {
 
     // json in java
     implementation group: 'org.json', name: 'json', version: '20220320'
+
+    // Thymeleaf (뷰 템플릿 엔진)
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 }
 
 tasks.named('test') {

--- a/yoseobara/src/main/java/com/final2/yoseobara/config/SecurityConfiguration.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/config/SecurityConfiguration.java
@@ -73,6 +73,7 @@ public class SecurityConfiguration {
                 .antMatchers("/api/member/**").permitAll()   //signup, login 해제
                 .antMatchers(HttpMethod.GET, "/api/**").permitAll()   // Get 요청 해제
                 .antMatchers("/api/posts/bounds").permitAll()  // 지도 조회 허용
+                .antMatchers(HttpMethod.GET, "/login").permitAll()
                 .antMatchers(HttpMethod.GET, "/member/kakao/callback").permitAll()   // 카카오 소셜로그인 Get 요청 해제
                 .anyRequest().authenticated()
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/config/SecurityConfiguration.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/config/SecurityConfiguration.java
@@ -73,6 +73,7 @@ public class SecurityConfiguration {
                 .antMatchers("/api/member/**").permitAll()   //signup, login 해제
                 .antMatchers(HttpMethod.GET, "/api/**").permitAll()   // Get 요청 해제
                 .antMatchers("/api/posts/bounds").permitAll()  // 지도 조회 허용
+                .antMatchers(HttpMethod.GET, "/member/kakao/callback").permitAll()   // 카카오 소셜로그인 Get 요청 해제
                 .anyRequest().authenticated()
 
                 .and()

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/KakaoController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/KakaoController.java
@@ -1,0 +1,12 @@
+package com.final2.yoseobara.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class KakaoController {
+    @GetMapping("/login")
+    public String kakao(){
+        return "login";
+    }
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.final2.yoseobara.dto.request.LoginRequestDto;
 import com.final2.yoseobara.dto.request.MemberRequestDto;
 import com.final2.yoseobara.dto.request.TokenDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
+import com.final2.yoseobara.service.KakaoMemberService;
 import com.final2.yoseobara.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,8 @@ import javax.validation.Valid;
 public class MemberController {
 
     private final MemberService memberService;
+
+    private final KakaoMemberService kakaoMemberService;
 
     @RequestMapping(value = "/api/member/signup", method = RequestMethod.POST)
     public ResponseDto<?> signup(@RequestBody @Valid MemberRequestDto requestDto) {
@@ -37,10 +40,9 @@ public class MemberController {
     }
 
     @GetMapping("/member/kakao/callback")
-    public String kakaoLogin(@RequestParam String code) throws JsonProcessingException {
-        kakaoMemberService.kakaoLogin(code); //인가코드를 받아서 서비스한테 넘겨줌.
-        return "redirect:/"; //리다이렉트
-
+    public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+        kakaoMemberService.kakaoLogin(code, response);
+        return "redirect:/";
     }
 
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -40,9 +40,8 @@ public class MemberController {
     }
 
     @GetMapping("/member/kakao/callback")
-    public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
-        kakaoMemberService.kakaoLogin(code, response);
-        return "redirect:/";
+    public TokenDto kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+        return kakaoMemberService.kakaoLogin(code, response);
     }
 
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -1,15 +1,15 @@
 package com.final2.yoseobara.controller;
 
+import antlr.Token;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.final2.yoseobara.dto.request.NicknameRequestDto;
 import com.final2.yoseobara.dto.request.LoginRequestDto;
 import com.final2.yoseobara.dto.request.MemberRequestDto;
+import com.final2.yoseobara.dto.request.TokenDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -25,22 +25,24 @@ public class MemberController {
         return memberService.createUser(requestDto);
     }
 
-
     @RequestMapping(value = "/api/member/signup/nicknameCheck", method = RequestMethod.POST)
     public int nicknameCheck(@RequestBody @Valid NicknameRequestDto nicknameRequestDto) {
         return memberService.nicknameCheck(nicknameRequestDto);
     }
 
-
-
-
-
     @RequestMapping(value = "/api/member/login", method = RequestMethod.POST)
     public ResponseDto<?> login(@RequestBody @Valid LoginRequestDto requestDto,
-                                HttpServletResponse response
-    ) {
+                                HttpServletResponse response) {
         return memberService.login(requestDto, response);
     }
+
+    @GetMapping("/member/kakao/callback")
+    public String kakaoLogin(@RequestParam String code) throws JsonProcessingException {
+        memberService.kakaoLogin(code); //인가코드를 받아서 서비스한테 넘겨줌.
+        return "redirect:/"; //리다이렉트
+
+    }
+
 
 
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -38,7 +38,7 @@ public class MemberController {
 
     @GetMapping("/member/kakao/callback")
     public String kakaoLogin(@RequestParam String code) throws JsonProcessingException {
-        memberService.kakaoLogin(code); //인가코드를 받아서 서비스한테 넘겨줌.
+        kakaoMemberService.kakaoLogin(code); //인가코드를 받아서 서비스한테 넘겨줌.
         return "redirect:/"; //리다이렉트
 
     }

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -2,10 +2,7 @@ package com.final2.yoseobara.controller;
 
 import antlr.Token;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.final2.yoseobara.dto.request.NicknameRequestDto;
-import com.final2.yoseobara.dto.request.LoginRequestDto;
-import com.final2.yoseobara.dto.request.MemberRequestDto;
-import com.final2.yoseobara.dto.request.TokenDto;
+import com.final2.yoseobara.dto.request.*;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.service.KakaoMemberService;
 import com.final2.yoseobara.service.MemberService;
@@ -40,13 +37,7 @@ public class MemberController {
     }
 
     @GetMapping("/member/kakao/callback")
-    public TokenDto kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+    public KakaoTokenDto kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
         return kakaoMemberService.kakaoLogin(code, response);
     }
-
-
-
-
-
-
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
@@ -36,6 +36,9 @@ public class Member extends Timestamped {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(unique = true)
+    private Long kakaoId;
+
     // OneToMany 는 기본적으로 LAZY 로딩, 매번 직접 추가해줘야 하는지?
     @OneToMany(mappedBy = "member")
     @JsonIgnore
@@ -69,6 +72,10 @@ public class Member extends Timestamped {
     // 포스트 리스트 추가
     public void mapToPost(final Post post) {
         posts.add(post);
+    }
+
+    public Member(String email, String encodedPassword, String nickname, Long kakaoId) {
+        super();
     }
 }
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
@@ -73,10 +73,6 @@ public class Member extends Timestamped {
     public void mapToPost(final Post post) {
         posts.add(post);
     }
-
-    public Member(String email, String encodedPassword, String nickname, Long kakaoId) {
-        super();
-    }
 }
 
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/UserDetailsImpl.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/UserDetailsImpl.java
@@ -26,6 +26,7 @@ public class UserDetailsImpl implements UserDetails {
         return authorities;
     }
 
+    public Long getId() { return member.getMemberId(); }
     @Override
     public String getPassword() {
         return member.getPassword();

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoTokenDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoTokenDto.java
@@ -1,0 +1,18 @@
+package com.final2.yoseobara.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KakaoTokenDto {
+    private String nickname;
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoUserInfoDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoUserInfoDto.java
@@ -1,7 +1,9 @@
 package com.final2.yoseobara.dto.request;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public class KakaoUserInfoDto {
     private Long id;

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoUserInfoDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/KakaoUserInfoDto.java
@@ -1,0 +1,11 @@
+package com.final2.yoseobara.dto.request;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String nickname;
+    private String email;
+}
+

--- a/yoseobara/src/main/java/com/final2/yoseobara/jwt/TokenProvider.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/jwt/TokenProvider.java
@@ -74,8 +74,40 @@ public class TokenProvider {
                 .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
                 .refreshToken(refreshToken)
                 .build();
-
     }
+
+    public TokenDto kakaoGenerateTokenDto(UserDetailsImpl member) {
+        long now = (new Date().getTime());
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+                .setSubject(member.getUsername())
+                .claim(AUTHORITIES_KEY, Authority.ROLE_MEMBER.toString())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPRIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        RefreshToken refreshTokenObject = RefreshToken.builder()
+                .id(member.getId())
+                .member(member.getMember())
+                .refreshTokenValue(refreshToken)
+                .build();
+
+        refreshTokenRepository.save(refreshTokenObject);
+
+        return TokenDto.builder()
+                .grantType(BEARER_PREFIX)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
+    }
+
     public Member getUserFromAuthentication() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || AnonymousAuthenticationToken.class.

--- a/yoseobara/src/main/java/com/final2/yoseobara/jwt/TokenProvider.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/jwt/TokenProvider.java
@@ -1,5 +1,7 @@
 package com.final2.yoseobara.jwt;
 
+import com.final2.yoseobara.dto.request.KakaoTokenDto;
+import com.final2.yoseobara.dto.request.KakaoUserInfoDto;
 import com.final2.yoseobara.dto.request.TokenDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.domain.RefreshToken;
@@ -76,7 +78,7 @@ public class TokenProvider {
                 .build();
     }
 
-    public TokenDto kakaoGenerateTokenDto(UserDetailsImpl member) {
+    public KakaoTokenDto kakaoGenerateTokenDto(UserDetailsImpl member, KakaoUserInfoDto kakaoUserInfoDto) {
         long now = (new Date().getTime());
 
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
@@ -100,7 +102,8 @@ public class TokenProvider {
 
         refreshTokenRepository.save(refreshTokenObject);
 
-        return TokenDto.builder()
+        return KakaoTokenDto.builder()
+                .nickname(kakaoUserInfoDto.getNickname())
                 .grantType(BEARER_PREFIX)
                 .accessToken(accessToken)
                 .accessTokenExpiresIn(accessTokenExpiresIn.getTime())

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/MemberRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByNickname(String nickname);
 
+    Optional<Member> findByKakaoId(Long kakaoId);
+
     Optional<Member> findById(Long Id);
 
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/KakaoMemberService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/KakaoMemberService.java
@@ -1,0 +1,141 @@
+package com.final2.yoseobara.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.final2.yoseobara.domain.Member;
+import com.final2.yoseobara.domain.UserDetailsImpl;
+import com.final2.yoseobara.dto.request.KakaoUserInfoDto;
+import com.final2.yoseobara.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class KakaoMemberService {
+
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    public void kakaoLogin(String code) throws JsonProcessingException {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getAccessToken(code);
+
+        // 2. 토큰으로 카카오 API 호출
+        KakaoUserInfoDto kakaoMemberInfoDto = getKakaoUserInfo(accessToken);
+
+        // 3. 필요시에 회원가입
+        Member kakaoMember = createKakaoMemberIfNeeded(kakaoMemberInfoDto);
+
+        // 4. 강제 로그인 처리
+        forceLogin(kakaoMember);
+    }
+
+    private String getAccessToken(String code) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "e293cafd847d24faa5079a9e55814232");
+        body.add("redirect_uri", "http://localhost:8080/member/kakao/callback");
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        return jsonNode.get("access_token").asText(); //인라인 변수
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
+
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        System.out.println("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoUserInfoDto(id, nickname, email);
+    }
+
+    private Member createKakaoMemberIfNeeded(KakaoUserInfoDto kakaoMemberInfoDto) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoMemberInfoDto.getId();
+        Member kakaoMember = memberRepository.findByKakaoId(kakaoId)
+                .orElse(null);
+        if (kakaoMember == null) {
+            // 회원가입
+            // username: kakao email
+            String email = kakaoMemberInfoDto.getEmail();
+
+            // password: random UUID
+            String password = UUID.randomUUID().toString();
+            String encodedPassword = passwordEncoder.encode(password);
+
+            String nickname = kakaoMemberInfoDto.getNickname();
+
+
+            kakaoMember = new Member(email, encodedPassword, nickname, kakaoId);
+            memberRepository.save(kakaoMember);
+        }
+        return kakaoMember;
+    }
+
+    private void forceLogin(Member kakaoMember) {
+        UserDetails userDetails = new UserDetailsImpl(kakaoMember);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+}
+
+
+

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
@@ -1,9 +1,9 @@
 package com.final2.yoseobara.service;
 
-import com.final2.yoseobara.dto.request.LoginRequestDto;
-import com.final2.yoseobara.dto.request.NicknameRequestDto;
-import com.final2.yoseobara.dto.request.TokenDto;
-import com.final2.yoseobara.dto.request.MemberRequestDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.final2.yoseobara.dto.request.*;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.dto.response.MemberResponseDto;
 import com.final2.yoseobara.domain.Member;
@@ -11,9 +11,16 @@ import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.jwt.TokenProvider;
 import com.final2.yoseobara.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
@@ -99,11 +106,74 @@ public class MemberService {
         );
     }
 
+    public void kakaoLogin(String code) throws JsonProcessingException {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getAccessToken(code);
+
+        // 2. 토큰으로 카카오 API 호출
+        KakaoUserInfoDto kakaoUserInfoDto = getKakaoUserInfo(accessToken);
+    }
+
+    private String getAccessToken(String code) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "e293cafd847d24faa5079a9e55814232");
+        body.add("redirect_uri", "http://localhost:8080/member/kakao/callback");
+        body.add("code", code);
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        return jsonNode.get("access_token").asText(); //인라인 변수
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP 요청 보내기
+        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
+        RestTemplate rt = new RestTemplate();
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoUserInfoRequest,
+                String.class
+        );
 
 
+        String responseBody = response.getBody();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
 
-
-
+        System.out.println("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoUserInfoDto(id, nickname, email);
+    }
+    
     @Transactional(readOnly = true)
     public Member isPresentMember(String username) {
         Optional<Member> optionalMember = memberRepository.findByUsername(username);

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
@@ -1,26 +1,19 @@
 package com.final2.yoseobara.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.final2.yoseobara.dto.request.*;
-import com.final2.yoseobara.dto.response.ResponseDto;
-import com.final2.yoseobara.dto.response.MemberResponseDto;
 import com.final2.yoseobara.domain.Member;
+import com.final2.yoseobara.dto.request.LoginRequestDto;
+import com.final2.yoseobara.dto.request.MemberRequestDto;
+import com.final2.yoseobara.dto.request.NicknameRequestDto;
+import com.final2.yoseobara.dto.request.TokenDto;
+import com.final2.yoseobara.dto.response.MemberResponseDto;
+import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.jwt.TokenProvider;
 import com.final2.yoseobara.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletResponse;
 import java.util.Optional;
@@ -106,74 +99,6 @@ public class MemberService {
         );
     }
 
-    public void kakaoLogin(String code) throws JsonProcessingException {
-        // 1. "인가 코드"로 "액세스 토큰" 요청
-        String accessToken = getAccessToken(code);
-
-        // 2. 토큰으로 카카오 API 호출
-        KakaoUserInfoDto kakaoUserInfoDto = getKakaoUserInfo(accessToken);
-    }
-
-    private String getAccessToken(String code) throws JsonProcessingException {
-        // HTTP Header 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        // HTTP Body 생성
-        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-        body.add("grant_type", "authorization_code");
-        body.add("client_id", "e293cafd847d24faa5079a9e55814232");
-        body.add("redirect_uri", "http://localhost:8080/member/kakao/callback");
-        body.add("code", code);
-
-        // HTTP 요청 보내기
-        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
-                new HttpEntity<>(body, headers);
-        RestTemplate rt = new RestTemplate();
-        ResponseEntity<String> response = rt.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                kakaoTokenRequest,
-                String.class
-        );
-
-        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
-        String responseBody = response.getBody();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(responseBody);
-        return jsonNode.get("access_token").asText(); //인라인 변수
-    }
-
-    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
-        // HTTP Header 생성
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        // HTTP 요청 보내기
-        HttpEntity<MultiValueMap<String, String>> kakaoUserInfoRequest = new HttpEntity<>(headers);
-        RestTemplate rt = new RestTemplate();
-        ResponseEntity<String> response = rt.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.POST,
-                kakaoUserInfoRequest,
-                String.class
-        );
-
-
-        String responseBody = response.getBody();
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode jsonNode = objectMapper.readTree(responseBody);
-        Long id = jsonNode.get("id").asLong();
-        String nickname = jsonNode.get("properties")
-                .get("nickname").asText();
-        String email = jsonNode.get("kakao_account")
-                .get("email").asText();
-
-        System.out.println("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
-        return new KakaoUserInfoDto(id, nickname, email);
-    }
-    
     @Transactional(readOnly = true)
     public Member isPresentMember(String username) {
         Optional<Member> optionalMember = memberRepository.findByUsername(username);

--- a/yoseobara/src/main/resources/templates/login.html
+++ b/yoseobara/src/main/resources/templates/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+<div id="login-form">
+  <button id="login-kakao-btn" onclick="location.href='https://kauth.kakao.com/oauth/authorize?client_id=e293cafd847d24faa5079a9e55814232&redirect_uri=http://localhost:8080/member/kakao/callback&response_type=code'">
+    카카오로 로그인하기
+  </button>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- 프론트에서 인가코드 받아서 카카오에 액세스 토큰 요청
- 액세스 토큰으로 카카오 api 호출
- 카카오 사용자 정보로 서비스 이용할 수 있도록 회원가입 구현
- 강제 로그인 처리
- response Header에 JWT 토큰 추가(우리 서버 전용 토큰 발행)
- 리팩토링
- security Config 수정
- return 값 변경 등