### PR TITLE
feat: Add admin role, logged in member's information, Fix comment handling at remove post

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -1,15 +1,16 @@
 package com.final2.yoseobara.controller;
 
+import com.final2.yoseobara.domain.UserDetailsImpl;
 import com.final2.yoseobara.dto.request.NicknameRequestDto;
 import com.final2.yoseobara.dto.request.LoginRequestDto;
 import com.final2.yoseobara.dto.request.MemberRequestDto;
+import com.final2.yoseobara.dto.response.MemberResponseDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
+import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -17,7 +18,6 @@ import javax.validation.Valid;
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
-
     private final MemberService memberService;
 
     @RequestMapping(value = "/api/member/signup", method = RequestMethod.POST)
@@ -32,9 +32,6 @@ public class MemberController {
     }
 
 
-
-
-
     @RequestMapping(value = "/api/member/login", method = RequestMethod.POST)
     public ResponseDto<?> login(@RequestBody @Valid LoginRequestDto requestDto,
                                 HttpServletResponse response
@@ -42,8 +39,18 @@ public class MemberController {
         return memberService.login(requestDto, response);
     }
 
-
-
-
-
+    // 로그인된 멤버 정보 조회
+    @GetMapping("api/member/myinfo")
+    public ResponseDto<?> myinfo(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+        // 로그인 확인
+        if (userDetailsImpl == null) {
+            return ResponseDto.fail(ErrorCode.LOGIN_REQUIRED);
+        }
+        // 정보 가져오기
+        return ResponseDto.success(MemberResponseDto.builder()
+                .id(userDetailsImpl.getMember().getMemberId())
+                .username(userDetailsImpl.getMember().getUsername())
+                .nickname(userDetailsImpl.getMember().getNickname())
+                .build());
+    }
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -51,6 +51,7 @@ public class MemberController {
                 .id(userDetailsImpl.getMember().getMemberId())
                 .username(userDetailsImpl.getMember().getUsername())
                 .nickname(userDetailsImpl.getMember().getNickname())
+                .authority(userDetailsImpl.getMember().getAuthority())
                 .build());
     }
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Member.java
@@ -1,6 +1,7 @@
 package com.final2.yoseobara.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.final2.yoseobara.shared.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,6 +45,10 @@ public class Member extends Timestamped {
     @OneToMany(mappedBy = "member")
     @JsonIgnore
     private List<Comment> comments;
+
+    @Enumerated(EnumType.STRING)
+    @JsonIgnore
+    private Authority authority;
 
     @Override
     public boolean equals(Object o) {

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/MemberResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/MemberResponseDto.java
@@ -2,6 +2,7 @@ package com.final2.yoseobara.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.final2.yoseobara.dto.request.TokenDto;
+import com.final2.yoseobara.shared.Authority;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,8 @@ public class MemberResponseDto {
     private Long id;
     private String username;
     private String nickname;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Authority authority;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private TokenDto token;
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/MemberResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.final2.yoseobara.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.final2.yoseobara.dto.request.TokenDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,7 +17,10 @@ public class MemberResponseDto {
     private Long id;
     private String username;
     private String nickname;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private TokenDto token;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime createdAt;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private LocalDateTime modifiedAt;
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/CommentRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.final2.yoseobara.repository;
 
 import com.final2.yoseobara.domain.Comment;
+import com.final2.yoseobara.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPostPostId(Long postId);
+
+    void deleteAllByPost(Post postFoundById);
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/CommentService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/CommentService.java
@@ -10,6 +10,7 @@ import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.exception.InvalidValueException;
 import com.final2.yoseobara.repository.CommentRepository;
 import com.final2.yoseobara.repository.PostRepository;
+import com.final2.yoseobara.shared.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -69,7 +70,7 @@ public class CommentService {
         );
 
         // 코멘트 수정 권한 확인
-        if (!comment.getMember().getMemberId().equals(member.getMemberId())) {
+        if (!(comment.getMember().getMemberId().equals(member.getMemberId()) || member.getAuthority().equals(Authority.ROLE_ADMIN))) {
             throw new InvalidValueException(ErrorCode.COMMENT_UNAUTHORIZED);
         }
 
@@ -97,7 +98,7 @@ public class CommentService {
         );
 
         // 코멘트 삭제 권한 확인
-        if (!comment.getMember().getMemberId().equals(member.getMemberId())) {
+        if (!(comment.getMember().getMemberId().equals(member.getMemberId()) || member.getAuthority().equals(Authority.ROLE_ADMIN))) {
             throw new InvalidValueException(ErrorCode.COMMENT_UNAUTHORIZED);
         }
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/MemberService.java
@@ -10,6 +10,7 @@ import com.final2.yoseobara.domain.Member;
 import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.jwt.TokenProvider;
 import com.final2.yoseobara.repository.MemberRepository;
+import com.final2.yoseobara.shared.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -46,6 +47,7 @@ public class MemberService {
                 .username(requestDto.getUsername())
                 .password(passwordEncoder.encode(requestDto.getPassword()))
                 .nickname(requestDto.getNickname())
+                .authority(Authority.ROLE_MEMBER)
                 .build();
         memberRepository.save(member);
         return ResponseDto.success(

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -12,6 +12,7 @@ import com.final2.yoseobara.exception.InvalidValueException;
 import com.final2.yoseobara.repository.CommentRepository;
 import com.final2.yoseobara.repository.MemberRepository;
 import com.final2.yoseobara.repository.PostRepository;
+import com.final2.yoseobara.shared.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -172,8 +173,8 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new InvalidValueException(ErrorCode.POST_NOT_FOUND));
 
-        // 로그인된 유저와 게시글 작성자가 같은지 확인
-        if (!Objects.equals(memberFoundById.getMemberId(), post.getMember().getMemberId())) {
+        // 로그인된 유저와 게시글 작성자가 같지 않거나 관리자가 아니면 수정 불가
+        if (!(Objects.equals(memberFoundById.getMemberId(), post.getMember().getMemberId()) || memberFoundById.getAuthority() == Authority.ROLE_ADMIN)) {
             throw new InvalidValueException(ErrorCode.POST_UNAUTHORIZED);
         }
 
@@ -199,14 +200,14 @@ public class PostService {
         // 나머지 데이터 업데이트
         post.update(postRequestDto.getTitle(), postRequestDto.getContent(), address, postRequestDto.getLocation());
         // 멤버 정보 추가
-        post.mapToMember(memberFoundById);
+        //post.mapToMember(memberFoundById);
         // DB에 저장
         postRepository.save(post);
 
         return PostResponseDto.builder()
                 .post(post)
                 .imageUrls(post.getImageUrls())
-                .nickname(memberFoundById.getNickname())
+                .nickname(post.getMember().getNickname())
                 .build();
     }
 
@@ -221,8 +222,8 @@ public class PostService {
         Post postFoundById = postRepository.findById(postId)
                 .orElseThrow(() -> new InvalidValueException(ErrorCode.POST_NOT_FOUND));
 
-        // 로그인된 유저와 게시글 작성자가 같은지 확인
-        if (!Objects.equals(memberFoundById.getMemberId(), postFoundById.getMember().getMemberId())) {
+        // 로그인된 유저와 게시글 작성자가 같지 않거나 관리자가 아니면 삭제 불가
+        if (!(Objects.equals(memberFoundById.getMemberId(), postFoundById.getMember().getMemberId()) || memberFoundById.getAuthority() == Authority.ROLE_ADMIN)) {
             throw new InvalidValueException(ErrorCode.POST_UNAUTHORIZED);
         }
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -9,6 +9,7 @@ import com.final2.yoseobara.domain.Member;
 import com.final2.yoseobara.domain.Post;
 import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.exception.InvalidValueException;
+import com.final2.yoseobara.repository.CommentRepository;
 import com.final2.yoseobara.repository.MemberRepository;
 import com.final2.yoseobara.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final CommentRepository commentRepository;
     private final S3Service s3Service;
     private final MapService mapService;
 
@@ -223,6 +225,9 @@ public class PostService {
         if (!Objects.equals(memberFoundById.getMemberId(), postFoundById.getMember().getMemberId())) {
             throw new InvalidValueException(ErrorCode.POST_UNAUTHORIZED);
         }
+
+        // 게시물에 달린 댓글 삭제
+        commentRepository.deleteAllByPost(postFoundById);
 
         // 게시물 이미지 삭제
         for (String imageUrl : postFoundById.getImageUrls()) {

--- a/yoseobara/src/main/java/com/final2/yoseobara/shared/Authority.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/shared/Authority.java
@@ -2,5 +2,6 @@ package com.final2.yoseobara.shared;
 
 public enum Authority {
     ROLE_MEMBER,
-    ROLE_GUEST
+    ROLE_GUEST,
+    ROLE_ADMIN
 }


### PR DESCRIPTION
- 권한에 admin role 추가 (기존에 있던 것)
- 멤버에 권한 필드 추가(일단 멤버, 관리자 중 하나)
- 회원가입 시에 기본 role 멤버로 설정
- 내 정보 조회 시에 권한 출력
- 관리자의 경우 게시물 수정/삭제 가능 (출력 문제 수정)
- 관리자의 경우 댓글 수정/삭제 가능

- 로그인된 멤버의 정보를 조회하는 API 추가

- 포스트 삭제 시 코멘트 처리
- jpa 사용하여 코멘트 삭제 (속도가 느린 것 같음)

resolves #56, #52, #58