### PR TITLE
refactor: Change image processing, Add post listing by member id, Add member id in post response 

### DIFF
--- a/yoseobara/build.gradle
+++ b/yoseobara/build.gradle
@@ -56,6 +56,10 @@ dependencies {
 
     // json in java
     implementation group: 'org.json', name: 'json', version: '20220320'
+
+    // mock multipart file
+    implementation group: 'org.springframework', name: 'spring-test', version: '5.3.13'
+
 }
 
 tasks.named('test') {

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -66,7 +66,17 @@ public class MemberController {
                 .build());
     }
 
-    // 유저페이지 리스팅 (페이지)
+    // 유저페이지 리스팅 (페이지) - 멤버 아이디로
+    // 정렬, 검색 가능
+    @GetMapping("/posts/{memberId}")
+    public ResponseDto<?> getPostPageByMemberId(@PathVariable Long memberId,
+                                                @RequestParam(value = "search", defaultValue = "") String search,
+                                                @RequestParam(value = "keyword", defaultValue = "") String keyword,
+                                                @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable){
+        return ResponseDto.success(postService.getPostPageByMemberId(memberId, search, keyword, pageable));
+    }
+
+    // 유저페이지 리스팅 (페이지) - 닉네임으로
     // 정렬, 검색 가능
     @GetMapping("/posts/{nickname}")
     public ResponseDto<?> getPostPageByNickname(@PathVariable String nickname,

--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/PostController.java
@@ -7,7 +7,6 @@ import com.final2.yoseobara.dto.response.PostResponseDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.domain.UserDetailsImpl;
 import com.final2.yoseobara.exception.ErrorCode;
-import com.final2.yoseobara.repository.PostRepository;
 import com.final2.yoseobara.service.PostService;
 import com.final2.yoseobara.service.S3Service;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -82,7 +80,7 @@ public class PostController {
         Long memberId = userDetailsImpl.getMember().getMemberId();
 
         // 이미지 파일 1개 이상 3개 이하
-        if (images == null) {
+        if (images[0].isEmpty()) {
             return ResponseDto.fail(ErrorCode.POST_IMAGE_REQUIRED);
         } else if (images.length > 3) {
             return ResponseDto.fail(ErrorCode.POST_IMAGE_MAX);
@@ -90,8 +88,10 @@ public class PostController {
 
         // 이미지 S3 업로드
         List<String> imageUrls = s3Service.uploadFile(images);
+        // 첫번째 이미지로 썸네일
+        String thumbnailUrl = s3Service.uploadThumbnail(images[0], imageUrls.get(0).split("/")[3]);
 
-        return ResponseDto.success(postService.createPost(postRequestDto, imageUrls, memberId));
+        return ResponseDto.success(postService.createPost(postRequestDto, thumbnailUrl, imageUrls, memberId));
     }
 
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Image.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Image.java
@@ -1,0 +1,37 @@
+package com.final2.yoseobara.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Setter
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
+    private Long imageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    @JsonIgnore
+    private Post post;
+
+    private Integer imageOrder;
+
+    private String imageUrl;
+
+    @Builder
+    public Image(Post post, Integer imageOrder, String imageUrl) {
+        this.post = post;
+        this.imageOrder = imageOrder;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/domain/Post.java
@@ -6,12 +6,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -52,9 +50,13 @@ public class Post extends Timestamped {
 //    @ElementCollection(targetClass = String.class) // 값 타입 컬렉션 맵, 기본적으로 OneToMany
 //    private List<String> imageUrls;
 
-    @Column(columnDefinition = "json")
-    @Type(type = "json") // json 으로 리스트 넣음. 괜찮은지 모름
-    private List<String> imageUrls;
+//    @Column(columnDefinition = "json")
+//    @Type(type = "json") // json 으로 리스트 넣음. 괜찮은지 모름
+//    private List<String> imageUrls;
+
+    @OneToMany(mappedBy = "post")
+    @JsonIgnore // 상세에만 보이게 하기 위해
+    private List<Image> image;
 
     @Column
     private String thumbnailUrl;
@@ -73,7 +75,7 @@ public class Post extends Timestamped {
     }
 
     @Builder
-    public Post(String title, String content,String address, HashMap<String,Double> location, List<String> imageUrls) {
+    public Post(String title, String content,String address, HashMap<String,Double> location, String thumbnailUrl) {
         //this.member = member;
         this.title = title;
         this.content = content;
@@ -84,9 +86,9 @@ public class Post extends Timestamped {
 //        this.location.put("lat",location.get("lat"));
 //        this.location.put("lng",location.get("lng"));
         // 서브리스트 문제 때문에 임시로 만든 변수
-        List<String> temp = new ArrayList<>(imageUrls.subList(1,imageUrls.size()));
-        this.imageUrls = temp;
-        this.thumbnailUrl = imageUrls.get(0);
+//        List<String> temp = new ArrayList<>(imageUrls.subList(1,imageUrls.size()));
+//        this.imageUrls = temp;
+        this.thumbnailUrl = thumbnailUrl;
         this.view = 0L;
         this.heart = 0L;
     }

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/request/PostRequestDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/request/PostRequestDto.java
@@ -14,4 +14,5 @@ public class PostRequestDto {
     private String content;
     private String address;
     private HashMap<String,Double> location;
+    private List<Integer> deleteImageOrders;
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
@@ -22,14 +22,15 @@ public class PostResponseDto {
     private final LocalDateTime modifiedAt;
     private List<String> imageUrls;
     private String thumbnailUrl;
-    private Long view;
+
+    private Long view; // 조회수 계산
     private Long heart; // 좋아요 계산
     private Boolean myHeart; // 좋아요 여부
     private String nickname; // 로그인된 작성자의 닉네임 받아오기
-    private Long memberId;
+    private Long memberId; // 로그인된 작성자의 id 받아오기
 
     @Builder // 이미지와 썸네일 추가하기
-    public PostResponseDto(Post post, List<String> imageUrls, String nickname, Long heart, Boolean myHeart, Long view, Long memberId) {
+    public PostResponseDto(Post post, List<String> imageUrls, Boolean myHeart) {
         this.postId = post.getPostId();
         this.title = post.getTitle();
         this.content = post.getContent();
@@ -41,10 +42,10 @@ public class PostResponseDto {
         this.modifiedAt = post.getModifiedAt();
         this.imageUrls = imageUrls;
         this.thumbnailUrl = post.getThumbnailUrl();
-        this.view = view;
-        this.heart = heart;
+        this.view = post.getView();
+        this.heart = post.getHeart();
         this.myHeart = myHeart != null && myHeart; // null 일 때 false
-        this.nickname = nickname;
-        this.memberId = memberId;
+        this.nickname = post.getMember().getNickname();
+        this.memberId = post.getMember().getMemberId();
     }
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/PostResponseDto.java
@@ -1,7 +1,6 @@
 package com.final2.yoseobara.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.final2.yoseobara.domain.Member;
 import com.final2.yoseobara.domain.Post;
 import lombok.Builder;
 import lombok.Getter;

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/HeartRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/HeartRepository.java
@@ -2,6 +2,7 @@ package com.final2.yoseobara.repository;
 
 import com.final2.yoseobara.domain.Heart;
 import com.final2.yoseobara.domain.Member;
+import com.final2.yoseobara.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,4 +12,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
     Optional<Heart> findHeartByMemberAndPostId(Member member, Long postId);
 
     Boolean existsByMember_MemberIdAndPostId(Long memberId, Long postId);
+
+    void deleteAllByPostId(Long postId);
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/ImageRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/ImageRepository.java
@@ -1,0 +1,23 @@
+package com.final2.yoseobara.repository;
+
+import com.final2.yoseobara.domain.Image;
+import com.final2.yoseobara.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    @Query("select i.imageUrl from Image i where i.post.postId = :postId order by i.imageOrder")
+    List<String> findImageUrls(Long postId);
+
+    Image findByPost_PostIdAndImageOrder(Long postId, Integer deleteImageOrder);
+
+    List<Image> findAllByPost_PostIdOrderByImageOrder(Long postId);
+
+    @Transactional
+    void deleteByImageId(Long imageId);
+
+    void deleteAllByPost(Post postFoundById);
+}

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/PostRepository.java
@@ -22,6 +22,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByMember_NicknameAndTitleContainingAndContentContaining(String nickname, String title, String content, Pageable pageable);
 
+    Page<Post> findAllByMember_MemberIdAndTitleContainingAndContentContaining(Long memberId, String title, String content, Pageable pageable);
+
     @Query("select p from Post p")
     public Slice<Post> findAllDefault(Pageable pageable);
 

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/PostService.java
@@ -2,6 +2,7 @@ package com.final2.yoseobara.service;
 
 
 
+import com.final2.yoseobara.domain.Image;
 import com.final2.yoseobara.domain.UserDetailsImpl;
 import com.final2.yoseobara.dto.request.MapRequestDto;
 import com.final2.yoseobara.dto.request.PostRequestDto;
@@ -10,10 +11,7 @@ import com.final2.yoseobara.domain.Member;
 import com.final2.yoseobara.domain.Post;
 import com.final2.yoseobara.exception.ErrorCode;
 import com.final2.yoseobara.exception.InvalidValueException;
-import com.final2.yoseobara.repository.CommentRepository;
-import com.final2.yoseobara.repository.HeartRepository;
-import com.final2.yoseobara.repository.MemberRepository;
-import com.final2.yoseobara.repository.PostRepository;
+import com.final2.yoseobara.repository.*;
 import com.final2.yoseobara.shared.Authority;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -34,6 +32,7 @@ public class PostService {
     private final S3Service s3Service;
     private final MapService mapService;
     private final HeartRepository heartRepository;
+    private final ImageRepository imageRepository;
 
     // Post 리스트 조회 - responseDto의 @Builder와 연계됨.
     public List<PostResponseDto> getPostList() {
@@ -47,10 +46,6 @@ public class PostService {
         for (Post post : posts) {
             PostResponseDto postResponseDto = PostResponseDto.builder()
                     .post(post)
-                    .imageUrls(post.getImageUrls())
-                    .nickname(post.getMember().getNickname())
-                    .heart(post.getHeart())
-                    .memberId(post.getMember().getMemberId())
                     .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, post.getPostId()))
                     .build();
             postList.add(postResponseDto);
@@ -71,12 +66,9 @@ public class PostService {
 
         return PostResponseDto.builder()
                 .post(post)
-                .view(post.getView())
-                .heart(post.getHeart())
-                .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, postid))
-                .imageUrls(post.getImageUrls())
-                .nickname(post.getMember().getNickname())
-                .memberId(post.getMember().getMemberId())
+                //.view(post.getView())
+                .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, postId))
+                .imageUrls(imageRepository.findImageUrls(postId))
                 .build();
     }
 
@@ -96,10 +88,6 @@ public class PostService {
         for (Post post : posts) {
             PostResponseDto postResponseDto = PostResponseDto.builder()
                     .post(post)
-                    .imageUrls(post.getImageUrls())
-                    .nickname(post.getMember().getNickname())
-                    .heart(post.getHeart())
-                    .memberId(post.getMember().getMemberId())
                     .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, post.getPostId()))
                     .build();
             postList.add(postResponseDto);
@@ -138,10 +126,6 @@ public class PostService {
                 case "":
                     return postRepository.findAllDefault(page).map(post -> PostResponseDto.builder()
                             .post(post)
-                            .imageUrls(post.getImageUrls())
-                            .nickname(post.getMember().getNickname())
-                            .heart(post.getHeart())
-                            .memberId(post.getMember().getMemberId())
                             .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, post.getPostId()))
                             .build());
             }
@@ -152,10 +136,6 @@ public class PostService {
         Slice<PostResponseDto> postDtoSlice = postSlice.map(
                 post -> PostResponseDto.builder()
                         .post(post)
-                        .imageUrls(post.getImageUrls())
-                        .nickname(post.getMember().getNickname())
-                        .heart(post.getHeart())
-                        .memberId(post.getMember().getMemberId())
                         .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, post.getPostId()))
                         .build()
         );
@@ -205,36 +185,42 @@ public class PostService {
 
 
     // Post 생성
-    public PostResponseDto createPost(PostRequestDto postRequestDto, List<String> imageUrls, Long memberId) {
+    public PostResponseDto createPost(PostRequestDto postRequestDto, String thumnailUrl, List<String> imageUrls, Long memberId) {
         Member memberFoundById = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저는 존재하지 않습니다.")); // 에러코드 수정
+                .orElseThrow(() -> new InvalidValueException(ErrorCode.USER_NOT_FOUND)); // 에러코드 수정
 
-        String address = mapService.getAddress(postRequestDto.getLocation().get("lat"), postRequestDto.getLocation().get("lng"));
-
+        //String address = mapService.getAddress(postRequestDto.getLocation().get("lat"), postRequestDto.getLocation().get("lng"));
 
         // 게시물 생성
         Post post = Post.builder()
                 //.member(memberFoundById)
                 .title(postRequestDto.getTitle())
                 .content(postRequestDto.getContent())
-                .address(address)
+                .address(postRequestDto.getAddress())
                 .location(postRequestDto.getLocation())
-                .imageUrls(imageUrls)
+                .thumbnailUrl(thumnailUrl)
                 .build();
         // 멤버 정보 추가
         post.mapToMember(memberFoundById);
         // DB에 저장
         postRepository.save(post);
-        
-        PostResponseDto postResponseDto = PostResponseDto.builder()
+
+        // 이미지 저장
+        for (String imageUrl : imageUrls) {
+            Image image = Image.builder()
+                    .post(post)
+                    .imageOrder(imageUrls.indexOf(imageUrl))
+                    .imageUrl(imageUrl)
+                    .build();
+            imageRepository.save(image);
+        }
+
+        return PostResponseDto.builder()
                 .post(post)
-                .imageUrls(post.getImageUrls())
-                .nickname(memberFoundById.getNickname())
-                .heart(post.getHeart())
-                .memberId(post.getMember().getMemberId())
+                .imageUrls(imageUrls)
                 .build();
-        return postResponseDto;
     }
+
 
     // Post 수정 -> 이미지 수정 어떤 방식으로 할까
     @Transactional
@@ -253,39 +239,68 @@ public class PostService {
             throw new InvalidValueException(ErrorCode.POST_UNAUTHORIZED);
         }
 
-        // 이미지가 존재하면 S3와 DB 업데이트 -> 이미지가 없으면 기존 이미지 유지이긴 한데 1개 이상으로 설정해서 일단 그냥 덮어씌우는 걸로
-        // 기존 이미지인지 확인 기능 찾아보기 (파일의 URL 혹은 메타데이터 등?)
-        if (newImages != null) {
-            // 이미지 1개 이상 3개 이하
-            if(newImages.length > 3) {
-                throw new InvalidValueException(ErrorCode.POST_IMAGE_MAX);
-            } else if (newImages.length < 1) {
-                throw new InvalidValueException(ErrorCode.POST_IMAGE_REQUIRED);
-            }
-
-            List<String> imageUrls = s3Service.updateFile(post.getImageUrls(), post.getThumbnailUrl(), newImages);
-            // 서브리스트 문제 때문에 임시로 만든 변수
-            List<String> temp = new ArrayList<>(imageUrls.subList(1, imageUrls.size()));
-            post.setImageUrls(temp);
-            post.setThumbnailUrl(imageUrls.get(0));
+        // 총 이미지 1개 이상 3개 이하
+        int newImageCount = newImages[0].isEmpty() ? 0 : newImages.length;  // multipartfile은 null이 아니라 빈 배열이 들어오는 듯
+        if (post.getImage().size() - postRequestDto.getDeleteImageOrders().size() + newImageCount > 3) {
+            throw new InvalidValueException(ErrorCode.POST_IMAGE_MAX);
+        } else if (post.getImage().size() - postRequestDto.getDeleteImageOrders().size() + newImageCount < 1) {
+            throw new InvalidValueException(ErrorCode.POST_IMAGE_REQUIRED);
         }
 
-        String address = mapService.getAddress(postRequestDto.getLocation().get("lat"), postRequestDto.getLocation().get("lng"));
+        List<String> imageUrls = new ArrayList<>();
 
-        // 나머지 데이터 업데이트
-        post.update(postRequestDto.getTitle(), postRequestDto.getContent(), address, postRequestDto.getLocation());
-        // 멤버 정보 추가
-        //post.mapToMember(memberFoundById);
-        // DB에 저장
-        postRepository.save(post);
+        // 삭제할 이미지는 삭제하고 나머지는 순서 새로 매김
+        if (Objects.nonNull(postRequestDto.getDeleteImageOrders())) {
+            List<Image> images = imageRepository.findAllByPost_PostIdOrderByImageOrder(postId);
+            int order = 0;
+            for (int i = 0; i < images.size(); i++) {
+                if (postRequestDto.getDeleteImageOrders().contains(i)) {
+                    imageRepository.deleteByImageId(images.get(i).getImageId());
+                } else {
+                    images.get(i).setImageOrder(order);
+                    imageRepository.save(images.get(i));
+                    imageUrls.add(images.get(i).getImageUrl());
+                    order++;
+                }
+            }
+        }
+
+        // 새로운 이미지가 존재하면 저장
+        if (!newImages[0].isEmpty()) {
+            List<String> newImageUrls = s3Service.uploadFile(newImages);
+            int order = post.getImage().size() - postRequestDto.getDeleteImageOrders().size();
+            for (String newImageUrl : newImageUrls) {
+                Image image = Image.builder()
+                        .post(post)
+                        .imageOrder(order)  // 뒤로 추가한다
+                        .imageUrl(newImageUrl)
+                        .build();
+                imageRepository.save(image);
+                imageUrls.add(newImageUrl);
+                order++;
+            }
+        }
+
+
+        // 썸네일 가진 이미지 삭제 시 새로운 썸네일 생성
+        if (postRequestDto.getDeleteImageOrders().contains(0)) {
+            // 모든 작업 반영된 후의 첫번째 이미지
+            String targetImageUrl = imageRepository.findByPost_PostIdAndImageOrder(postId, 0).getImageUrl();
+            // 새 썸네일 파일 만들기
+            MultipartFile file = s3Service.convertUrlToMultipartFile(targetImageUrl);
+            // 기존 썸네일 삭제
+            s3Service.deleteFile(post.getThumbnailUrl());
+            // 새 썸네일 업로드
+            post.setThumbnailUrl(s3Service.uploadThumbnail(file, targetImageUrl.split("/")[3]));
+        }
+
+        // 게시물 내용 수정
+        post.update(postRequestDto.getTitle(), postRequestDto.getContent(), postRequestDto.getAddress(), postRequestDto.getLocation());
 
         return PostResponseDto.builder()
                 .post(post)
-                .imageUrls(post.getImageUrls())
-                .nickname(memberFoundById.getNickname())
-                .heart(post.getHeart())
-                .memberId(post.getMember().getMemberId())
-                .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, post.getPostId()))
+                .imageUrls(imageUrls)
+                .myHeart(heartRepository.existsByMember_MemberIdAndPostId(memberId, postId))
                 .build();
     }
 
@@ -308,8 +323,14 @@ public class PostService {
         // 게시물에 달린 댓글 삭제
         commentRepository.deleteAllByPost(postFoundById);
 
+        // 게시물에 달린 좋아요 삭제
+        heartRepository.deleteAllByPostId(postFoundById.getPostId());
+
+        // 게시물에 달린 이미지 삭제
+        imageRepository.deleteAllByPost(postFoundById);
+
         // 게시물 이미지 삭제
-        for (String imageUrl : postFoundById.getImageUrls()) {
+        for (String imageUrl : postFoundById.getImage().stream().map(Image::getImageUrl).toList()) {
             s3Service.deleteFile(imageUrl);
         }
         


### PR DESCRIPTION
- 이미지 관리/처리 방식 변경
- 기존 String 으로 관리하던 이미지 URL Entity로 관리
- 이미지 생성 시 파일 없어도 에러 잡히지 않던 것 수정
- 이미지 수정 시 삭제할 이미지 순서를 받아서 처리 (기존의 모두 삭제 후 재업로드 방식에서 개선)
- 기존의 이미지로 썸네일 변경 시, 파일 다운로드 없이 URL로 처리
- 게시물 삭제 시 연관된 댓글, 좋아요, 이미지 삭제 처리

- 멤버 아이디로 페이지 조회 기능 추가
- 게시물 관련 응답에 멤버 아이디 추가

resolves #71 , #78