### PR TITLE
fix: 게시글 내 댓글 조회 시 최신순으로 정렬

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/CommentController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/CommentController.java
@@ -6,6 +6,9 @@ import com.final2.yoseobara.dto.request.CommentRequestDto;
 import com.final2.yoseobara.dto.response.ResponseDto;
 import com.final2.yoseobara.service.CommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,8 +21,9 @@ public class CommentController {
 
     // 게시글 코멘트 조회
     @GetMapping
-    public ResponseDto<?> getComment(@PathVariable Long postId) {
-        return ResponseDto.success(commentService.getComment(postId));
+    public ResponseDto<?> getComment(@PathVariable Long postId,
+                                     @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseDto.success(commentService.getComment(postId, pageable));
     }
 
     // 코멘트 작성

--- a/yoseobara/src/main/java/com/final2/yoseobara/dto/response/CommentResponseDto.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/dto/response/CommentResponseDto.java
@@ -16,6 +16,7 @@ public class CommentResponseDto {
     private String nickname;
     private Long commentId;
     private String content;
+    private Long memberId;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
@@ -24,6 +25,7 @@ public class CommentResponseDto {
 
     @Builder
     public CommentResponseDto(Comment comment) {
+        this.memberId = comment.getMember().getMemberId();
         this.postId = comment.getPost().getPostId();
         this.nickname = comment.getMember().getNickname();
         this.commentId = comment.getCommentId();

--- a/yoseobara/src/main/java/com/final2/yoseobara/repository/CommentRepository.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/repository/CommentRepository.java
@@ -4,15 +4,20 @@ import com.final2.yoseobara.domain.Comment;
 import com.final2.yoseobara.domain.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    List<Comment> findAllByPostPostId(Long postId);
+    List<Comment> findAllByPostPostId(Long postId, Pageable page);
 
     void deleteAllByPost(Post postFoundById);
 
     Page<Comment> findAllByMember_MemberId(Long memberId, Pageable page);
+
+    @Query("select p from Post p")
+    public Slice<Post> findAllDefault(Pageable pageable);
 }

--- a/yoseobara/src/main/java/com/final2/yoseobara/service/CommentService.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/service/CommentService.java
@@ -28,8 +28,12 @@ public class CommentService {
     private final PostRepository postRepository;
 
     // 게시글 코멘트 조회
-    public List<CommentResponseDto> getComment(Long postId) {
-        List<Comment> comments = commentRepository.findAllByPostPostId(postId);
+    public List<CommentResponseDto> getComment(Long postId, Pageable pageable) {
+
+        Sort sort = pageable.getSort().and(Sort.by("createdAt").descending());
+        Pageable page = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), sort);
+
+        List<Comment> comments = commentRepository.findAllByPostPostId(postId, page);
 
         return comments.stream()
                 .map(CommentResponseDto::new)
@@ -61,14 +65,14 @@ public class CommentService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new InvalidValueException(ErrorCode.POST_NOT_FOUND));
 
-        Comment commnet = commentRepository.save(Comment.builder()
+        Comment comment = commentRepository.save(Comment.builder()
                 .content(requestDto.getContent())
                 .member(member)
                 .post(post)
                 .build());
 
         return CommentResponseDto.builder()
-                .comment(commnet)
+                .comment(comment)
                 .build();
     }
 


### PR DESCRIPTION
- 게시글 내 댓글을 최신순으로 정렬
- 댓글 response에 memberId 추가
- 오타수정 등

Resolve: #14