### PR TITLE
fix: Fix duplicated api url

### DIFF
--- a/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
+++ b/yoseobara/src/main/java/com/final2/yoseobara/controller/MemberController.java
@@ -74,7 +74,7 @@ public class MemberController {
 
     // 유저페이지 리스팅 (페이지) - 닉네임으로
     // 정렬, 검색 가능
-    @GetMapping("/posts/{nickname}")
+    @GetMapping("/posts/nickname/{nickname}")
     public ResponseDto<?> getPostPageByNickname(@PathVariable String nickname,
                                                 @RequestParam(value = "search", defaultValue = "") String search,
                                                 @RequestParam(value = "keyword", defaultValue = "") String keyword,


### PR DESCRIPTION
- 중복되던 유저페이지의 api 들의 url 을 수정
- 멤버아이디를 통한 조회를 기본으로
- 닉네임을 통한 조회도 삭제하진 않았음

resolves #86